### PR TITLE
fix(files): deprecate *FileJson methods in favor of *FileJSON naming convention

### DIFF
--- a/packages/node-utilities/docs/README.md
+++ b/packages/node-utilities/docs/README.md
@@ -117,11 +117,13 @@
 - [fileExists](README.md#fileexists)
 - [findUp](README.md#findup)
 - [getFile](README.md#getfile)
-- [getFileJson](README.md#getfilejson)
+- [getFileJSON](README.md#getfilejson)
+- [getFileJson](README.md#getfilejson-1)
 - [isDirectory](README.md#isdirectory)
 - [mkdir](README.md#mkdir)
 - [saveFile](README.md#savefile)
-- [saveFileJson](README.md#savefilejson)
+- [saveFileJSON](README.md#savefilejson)
+- [saveFileJson](README.md#savefilejson-1)
 - [unlink](README.md#unlink)
 
 ### Imports Functions
@@ -533,6 +535,25 @@ Get file content
 
 ___
 
+### getFileJSON
+
+▸ **getFileJSON**(`filepath`, `fallback?`): `any`
+
+Get JSON from file
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `filepath` | `PathLike` |
+| `fallback?` | `any` |
+
+#### Returns
+
+`any`
+
+___
+
 ### getFileJson
 
 ▸ **getFileJson**(`filepath`, `fallback?`): `any`
@@ -600,6 +621,26 @@ Save file to disk
 | :------ | :------ | :------ |
 | `filepath` | `PathOrFileDescriptor` | `undefined` |
 | `content` | `string` \| `ArrayBufferView` | `undefined` |
+| `options` | `WriteFileOptions` | `'utf8'` |
+
+#### Returns
+
+`void`
+
+___
+
+### saveFileJSON
+
+▸ **saveFileJSON**(`filepath`, `content`, `options?`): `void`
+
+Save file to disk as JSON
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `filepath` | `PathOrFileDescriptor` | `undefined` |
+| `content` | `any` | `undefined` |
 | `options` | `WriteFileOptions` | `'utf8'` |
 
 #### Returns

--- a/packages/node-utilities/src/files.ts
+++ b/packages/node-utilities/src/files.ts
@@ -6,7 +6,14 @@ import path from 'path'
  * Save file to disk as JSON
  * @category Files
  */
-export const saveFileJson = (filepath: PathOrFileDescriptor, content: any, options: WriteFileOptions = 'utf8') => saveFile(filepath, `${JSON.stringify(content, null, '\t')}\n`, options)
+export const saveFileJSON = (filepath: PathOrFileDescriptor, content: any, options: WriteFileOptions = 'utf8') => saveFile(filepath, `${JSON.stringify(content, null, '\t')}\n`, options)
+
+/**
+ * Save file to disk as JSON
+ * @category Files
+ * @deprecated use saveFileJSON instead
+ */
+export const saveFileJson = saveFileJSON
 
 /** @category Files */
 export const fileExists = (filepath: PathLike) => fs.existsSync(filepath)
@@ -57,10 +64,17 @@ export function unlink(filepath: PathLike) {
  * Get JSON from file
  * @category Files
  */
-export function getFileJson(filepath: PathLike, fallback?: any) {
+export function getFileJSON(filepath: PathLike, fallback?: any) {
 	const content = getFile(filepath)
 	return content ? JSONParse(content, fallback) : fallback
 }
+
+/**
+ * Get JSON from file
+ * @category Files
+ * @deprecated use getFileJSON instead
+ */
+export const getFileJson = getFileJSON
 
 /** @category Files */
 export interface FindUpOptions {


### PR DESCRIPTION
This PR standardizes the naming convention for JSON file helpers

* Rename getFileJson to getFileJSON
* Create deprecated proxy function getFileJson for backwards compatibility
* Rename saveFileJson to saveFileJSON
* Create deprecated proxy function saveFileJson for backwards compatibility
* Updated docs to reflect changes