### PR TITLE
feat(numbers): add numberEven and numberOdd helper functions

### DIFF
--- a/packages/utilities/__tests__/numbers.test.ts
+++ b/packages/utilities/__tests__/numbers.test.ts
@@ -2,30 +2,30 @@ import {numberPad} from '../src'
 
 describe('numbers', () => {
 	it('numberPad(5) should return 05', () => {
-		expect(numberPad(5)).toEqual('05')
+		expect(numberPad(5)).toBe('05')
 	})
 
 	it('numberPad(5, 2) should return 05', () => {
-		expect(numberPad(5, 2)).toEqual('05')
+		expect(numberPad(5, 2)).toBe('05')
 	})
 
 	it('numberPad(50, 2) should return 50', () => {
-		expect(numberPad(50, 2)).toEqual('50')
+		expect(numberPad(50, 2)).toBe('50')
 	})
 
 	it('numberPad(500, 2) should return 500', () => {
-		expect(numberPad(500, 2)).toEqual('500')
+		expect(numberPad(500, 2)).toBe('500')
 	})
 
 	it('numberPad(5, 3) should return 005', () => {
-		expect(numberPad(5, 3)).toEqual('005')
+		expect(numberPad(5, 3)).toBe('005')
 	})
 
 	it('numberPad(50, 3) should return 050', () => {
-		expect(numberPad(50, 3)).toEqual('050')
+		expect(numberPad(50, 3)).toBe('050')
 	})
 
 	it('numberPad(500, 3) should return 500', () => {
-		expect(numberPad(500, 3)).toEqual('500')
+		expect(numberPad(500, 3)).toBe('500')
 	})
 })

--- a/packages/utilities/__tests__/numbers.test.ts
+++ b/packages/utilities/__tests__/numbers.test.ts
@@ -1,31 +1,32 @@
 import {numberPad} from '../src'
 
 describe('numbers', () => {
-	it('numberPad(5) should return 05', () => {
-		expect(numberPad(5)).toBe('05')
-	})
+	describe('numberPad', () => {
+		it('(5) should return 05', () => {
+			expect(numberPad(5)).toBe('05')
+		})
+		it('(5, 2) should return 05', () => {
+			expect(numberPad(5, 2)).toBe('05')
+		})
 
-	it('numberPad(5, 2) should return 05', () => {
-		expect(numberPad(5, 2)).toBe('05')
-	})
+		it('(50, 2) should return 50', () => {
+			expect(numberPad(50, 2)).toBe('50')
+		})
 
-	it('numberPad(50, 2) should return 50', () => {
-		expect(numberPad(50, 2)).toBe('50')
-	})
+		it('(500, 2) should return 500', () => {
+			expect(numberPad(500, 2)).toBe('500')
+		})
 
-	it('numberPad(500, 2) should return 500', () => {
-		expect(numberPad(500, 2)).toBe('500')
-	})
+		it('(5, 3) should return 005', () => {
+			expect(numberPad(5, 3)).toBe('005')
+		})
 
-	it('numberPad(5, 3) should return 005', () => {
-		expect(numberPad(5, 3)).toBe('005')
-	})
+		it('(50, 3) should return 050', () => {
+			expect(numberPad(50, 3)).toBe('050')
+		})
 
-	it('numberPad(50, 3) should return 050', () => {
-		expect(numberPad(50, 3)).toBe('050')
-	})
-
-	it('numberPad(500, 3) should return 500', () => {
-		expect(numberPad(500, 3)).toBe('500')
+		it('(500, 3) should return 500', () => {
+			expect(numberPad(500, 3)).toBe('500')
+		})
 	})
 })

--- a/packages/utilities/__tests__/numbers.test.ts
+++ b/packages/utilities/__tests__/numbers.test.ts
@@ -1,4 +1,4 @@
-import {numberPad} from '../src'
+import {numberEven, numberPad} from '../src'
 
 describe('numbers', () => {
 	describe('numberPad', () => {
@@ -27,6 +27,17 @@ describe('numbers', () => {
 
 		it('(500, 3) should return 500', () => {
 			expect(numberPad(500, 3)).toBe('500')
+		})
+	})
+
+	describe('numberEven', () => {
+		it.each([
+			[1, 2],
+			[2, 2],
+			[3, 4],
+			[4, 4]
+		])('should return %d as the even number %d', (subject, result) => {
+			expect(numberEven(subject)).toBe(result)
 		})
 	})
 })

--- a/packages/utilities/__tests__/numbers.test.ts
+++ b/packages/utilities/__tests__/numbers.test.ts
@@ -1,4 +1,4 @@
-import {numberEven, numberPad} from '../src'
+import {numberEven, numberOdd, numberPad} from '../src'
 
 describe('numbers', () => {
 	describe('numberPad', () => {
@@ -38,6 +38,17 @@ describe('numbers', () => {
 			[4, 4]
 		])('should return %d as the even number %d', (subject, result) => {
 			expect(numberEven(subject)).toBe(result)
+		})
+	})
+
+	describe('numberOdd', () => {
+		it.each([
+			[1, 1],
+			[2, 3],
+			[3, 3],
+			[4, 5]
+		])('should return %d as the odd number %d', (subject, result) => {
+			expect(numberOdd(subject)).toBe(result)
 		})
 	})
 })

--- a/packages/utilities/docs/README.md
+++ b/packages/utilities/docs/README.md
@@ -93,6 +93,8 @@
 - [formatCurrency](README.md#formatcurrency)
 - [formatPercentage](README.md#formatpercentage)
 - [maxDecimals](README.md#maxdecimals)
+- [numberEven](README.md#numbereven)
+- [numberOdd](README.md#numberodd)
 - [numberPad](README.md#numberpad)
 - [randomBetween](README.md#randombetween)
 
@@ -899,6 +901,44 @@ limit the amount of decimals to the given number
 | :------ | :------ | :------ | :------ |
 | `value` | `number` | `undefined` | the number to limit |
 | `max_places?` | `number` | `2` | the maximum number of decimals |
+
+#### Returns
+
+`number`
+
+___
+
+### numberEven
+
+▸ **numberEven**(`num`, `subtract?`): `number`
+
+Force a number to be even
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `num` | `number` | `undefined` | the number to force even |
+| `subtract?` | `boolean` | `false` | whether to subtract 1 from the number if it is odd |
+
+#### Returns
+
+`number`
+
+___
+
+### numberOdd
+
+▸ **numberOdd**(`num`, `subtract?`): `number`
+
+Force a number to be odd
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `num` | `number` | `undefined` | the number to force odd |
+| `subtract?` | `boolean` | `false` | whether to subtract 1 from the number if it is even |
 
 #### Returns
 

--- a/packages/utilities/src/numbers.ts
+++ b/packages/utilities/src/numbers.ts
@@ -77,3 +77,13 @@ export function randomBetween(min: number, max: number, inclusive = true): numbe
 	max = Math.floor(max)
 	return Math.floor(Math.random() * (max - min + (inclusive ? 1 : 0)) + min)
 }
+
+/**
+ * Force a number to be even
+ * @param {number} num - the number to force even
+ * @param {boolean} [subtract=false] - whether to subtract 1 from the number if it is odd
+ * @category Numbers
+ */
+export function numberEven(num: number, subtract = false): number {
+	return num % 2 === 0 ? num : num + (subtract ? -1 : 1)
+}

--- a/packages/utilities/src/numbers.ts
+++ b/packages/utilities/src/numbers.ts
@@ -87,3 +87,13 @@ export function randomBetween(min: number, max: number, inclusive = true): numbe
 export function numberEven(num: number, subtract = false): number {
 	return num % 2 === 0 ? num : num + (subtract ? -1 : 1)
 }
+
+/**
+ * Force a number to be odd
+ * @param {number} num - the number to force odd
+ * @param {boolean} [subtract=false] - whether to subtract 1 from the number if it is even
+ * @category Numbers
+ */
+export function numberOdd(num: number, subtract = false): number {
+	return num % 2 === 1 ? num : num + (subtract ? -1 : 1)
+}


### PR DESCRIPTION
This PR adds 2 new helper functions to the Numbers category

* numberEven - forces a number to be even by either adding (default) or subtracting 1 from odd numbers
* numberOdd - forces a number to be odd by either adding (default) or subtracting 1 from even numbers

All tests pass.
No breaking changes.